### PR TITLE
minor: Update image tag for full node in the docs

### DIFF
--- a/docs/canarynet/node/run-full-node.md
+++ b/docs/canarynet/node/run-full-node.md
@@ -26,7 +26,7 @@ For running `Validator Node`, please refer to the [next section](./run-validator
     -v "/chain:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -d \
-    atactr/automata:contextfree-v0.1.0-rc4 \
+    atactr/automata:contextfree-v0.1.0-rc5 \
     --node-type full \
     --name <YOUR_NODE_NAME>
   ```
@@ -40,7 +40,7 @@ For running `Validator Node`, please refer to the [next section](./run-validator
     -v "/chain:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -d \
-    atactr/automata:contextfree-v0.1.0-rc4 \
+    atactr/automata:contextfree-v0.1.0-rc5 \
     --node-type archive \
     --name <YOUR_NODE_NAME>
     ```


### PR DESCRIPTION
There was a problem in running full node for this tag contextfree-v0.1.0-rc4 as the peer count was always showing 0.

sample error:
```
2023-06-12 08:55:51 💤 Idle (0 peers), best: #0 (0x6254…c299), finalized #0 (0x6254…c299), ⬇ 0.4kiB/s ⬆ 0.3kiB/s
2023-06-12 08:55:55 💔 The bootnode you want to connect to at `/dns/cf-boot.ata.network/tcp/30333/ws/p2p/12D3KooWSuTq6MG9gPt7qZqLFKkYrfxMewTZhj9nmRHJkPwzWDG2` provided a different peer ID than the one you expect: `12D3KooWSuTq6MG9gPt7qZqLFKkYrfxMewTZhj9nmRHJkPwzWDG2`.
2023-06-12 08:55:55 💔 The bootnode you want to connect to at `/dns/cf-boot.ata.network/tcp/30334/ws/p2p/12D3KooWMz5U7fR8mF5DNhZSSyFN8c19kU63xYopzDSNCzoFigYk` provided a different peer ID than the one you expect: `12D3KooWMz5U7fR8mF5DNhZSSyFN8c19kU63xYopzDSNCzoFigYk`.```


updating the image tag fixed the issue